### PR TITLE
Add Query.Consistency() and .MapScanCAS()

### DIFF
--- a/query.go
+++ b/query.go
@@ -60,7 +60,7 @@ type Query interface {
 	SetConsistency(c gocql.Consistency)
 
 	// Consistency sets the consistency level for this query. If no consistency
-	// level have been set, the default consistency level of the cluster
+	// level has been set, the default consistency level of the cluster
 	// is used.
 	Consistency(c gocql.Consistency) Query
 }

--- a/query.go
+++ b/query.go
@@ -59,7 +59,9 @@ type Query interface {
 	// SetConsistency sets the consistency level for this query.
 	SetConsistency(c gocql.Consistency)
 
-	// SetConsistency sets the consistency level for this query.
+	// Consistency sets the consistency level for this query. If no consistency
+	// level have been set, the default consistency level of the cluster
+	// is used.
 	Consistency(c gocql.Consistency) Query
 }
 
@@ -176,8 +178,7 @@ func (q query) SetConsistency(c gocql.Consistency) {
 }
 
 func (q query) Consistency(c gocql.Consistency) Query {
-	q.q = q.q.Consistency(c)
-	return q
+	return &query{q: q.q.Consistency(c)}
 }
 
 func (q query) MapScanCAS(dest map[string]interface{}) (applied bool, err error) {

--- a/query_test.go
+++ b/query_test.go
@@ -3,9 +3,10 @@ package gockle
 import (
 	"context"
 	"fmt"
-	"github.com/gocql/gocql"
 	"reflect"
 	"testing"
+
+	"github.com/gocql/gocql"
 )
 
 func TestQuery(t *testing.T) {
@@ -73,9 +74,11 @@ func TestQueryMock(t *testing.T) {
 		{"Iter", nil, []interface{}{it}},
 		{"MapScan", []interface{}{map[string]interface{}(nil)}, []interface{}{nil}},
 		{"MapScan", []interface{}{map[string]interface{}{"a": 1}}, []interface{}{e}},
+		{"MapScanCAS", []interface{}{map[string]interface{}{"a": 1}}, []interface{}{true, e}},
 		{"Release", nil, nil},
 		{"GetConsistency", nil, []interface{}{gocql.Quorum}},
 		{"SetConsistency", []interface{}{gocql.One}, nil},
+		{"Consistency", []interface{}{gocql.One}, []interface{}{m}},
 	})
 }
 


### PR DESCRIPTION
Hey, by default MapScanCAS uses SERIAL consistency. I need to set LOCAL_SERIAL.
Intended use is `c.Query().Consistency().MapScanCAS()`. I couldn't find a way to set it using `.ScanMapTx()`